### PR TITLE
Fix the failure to connect to the database caused by setting the database name

### DIFF
--- a/bootstrap/database.go
+++ b/bootstrap/database.go
@@ -19,10 +19,10 @@ func NewMongoDatabase(env *Env) mongo.Client {
 	dbPass := env.DBPass
 	dbName := env.DBName
 
-	mongodbURI := fmt.Sprintf("mongodb://%s:%s@%s:%s/%s", dbUser, dbPass, dbHost, dbPort, dbName)
+	mongodbURI := fmt.Sprintf("mongodb://%s:%s@%s:%s", dbUser, dbPass, dbHost, dbPort)
 
 	if dbUser == "" || dbPass == "" {
-		mongodbURI = fmt.Sprintf("mongodb://%s:%s/%s", dbHost, dbPort, dbName)
+		mongodbURI = fmt.Sprintf("mongodb://%s:%s", dbHost, dbPort)
 	}
 
 	client, err := mongo.NewClient(mongodbURI)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=$DB_USER
       - MONGO_INITDB_ROOT_PASSWORD=$DB_PASS
-      - MONGO_INITDB_DATABASE=$DB_NAME
     ports:
       - "$DB_PORT:$DB_PORT"
     volumes:


### PR DESCRIPTION
```bash
2023/01/10 15:49:30 The App is running in development env
2023/01/10 07:49:30 connection() error occurred during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.
```
When authentication is required, creating a connection and specifying a database name causes authentication to fail.