### PR TITLE
Minify and secure docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM golang:1.19-alpine as builder
 WORKDIR /
 COPY go.mod .
-COPY go.sum .
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o main main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o main cmd/main.go
 
 FROM gcr.io/distroless/static:nonroot
-RUN mkdir /app
-WORKDIR /app
+WORKDIR /
 COPY --from=builder /main .
 USER 65532:65532
-ENTRYPOINT ["/app/main"]
+ENTRYPOINT ["/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1.19-alpine
+FROM golang:1.19-alpine as builder
+WORKDIR /
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o main main.go
 
+FROM gcr.io/distroless/static:nonroot
 RUN mkdir /app
-
-ADD . /app
-
 WORKDIR /app
-
-RUN go build -o main cmd/main.go
-
-CMD ["/app/main"]
+COPY --from=builder /main .
+USER 65532:65532
+ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
Heyho! I think you may consider updating the Dockerfile to make the image smaller and more secure

This change should minify it by separating the builder image with all of the Go tools needed to build the executable and the second image that consists of only the executable itself. It also uses a minimal base image so there are close to no tools that could be exploited, and the user is set to nonroot