### PR TITLE
Fix staticcheck issues

### DIFF
--- a/domain/jwt_custom.go
+++ b/domain/jwt_custom.go
@@ -7,10 +7,10 @@ import (
 type JwtCustomClaims struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 type JwtCustomRefreshClaims struct {
 	ID string `json:"id"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }

--- a/internal/tokenutil/tokenutil.go
+++ b/internal/tokenutil/tokenutil.go
@@ -9,12 +9,14 @@ import (
 )
 
 func CreateAccessToken(user *domain.User, secret string, expiry int) (accessToken string, err error) {
-	exp := time.Now().Add(time.Hour * time.Duration(expiry)).Unix()
+	nowTime := time.Now()
+	expireTime := nowTime.Add(time.Duration(expiry) * time.Hour)
+
 	claims := &domain.JwtCustomClaims{
 		Name: user.Name,
 		ID:   user.ID.Hex(),
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: exp,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expireTime),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -26,10 +28,13 @@ func CreateAccessToken(user *domain.User, secret string, expiry int) (accessToke
 }
 
 func CreateRefreshToken(user *domain.User, secret string, expiry int) (refreshToken string, err error) {
+	nowTime := time.Now()
+	expireTime := nowTime.Add(time.Duration(expiry) * time.Hour)
+
 	claimsRefresh := &domain.JwtCustomRefreshClaims{
 		ID: user.ID.Hex(),
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour * time.Duration(expiry)).Unix(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expireTime),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claimsRefresh)
@@ -43,7 +48,7 @@ func CreateRefreshToken(user *domain.User, secret string, expiry int) (refreshTo
 func IsAuthorized(requestToken string, secret string) (bool, error) {
 	_, err := jwt.Parse(requestToken, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(secret), nil
 	})
@@ -56,7 +61,7 @@ func IsAuthorized(requestToken string, secret string) (bool, error) {
 func ExtractIDFromToken(requestToken string, secret string) (string, error) {
 	token, err := jwt.Parse(requestToken, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(secret), nil
 	})
@@ -68,7 +73,7 @@ func ExtractIDFromToken(requestToken string, secret string) (string, error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 
 	if !ok && !token.Valid {
-		return "", fmt.Errorf("Invalid Token")
+		return "", fmt.Errorf("invalid Token")
 	}
 
 	return claims["id"].(string), nil

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -2,13 +2,8 @@ package mongo
 
 import (
 	"context"
-	"errors"
-	"reflect"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/bsoncodec"
-	"go.mongodb.org/mongo-driver/bson/bsonrw"
-	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -71,27 +66,6 @@ type mongoCursor struct {
 
 type mongoSession struct {
 	mongo.Session
-}
-
-type nullawareDecoder struct {
-	defDecoder bsoncodec.ValueDecoder
-	zeroValue  reflect.Value
-}
-
-func (d *nullawareDecoder) DecodeValue(dctx bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
-	if vr.Type() != bsontype.Null {
-		return d.defDecoder.DecodeValue(dctx, vr, val)
-	}
-
-	if !val.CanSet() {
-		return errors.New("value not settable")
-	}
-	if err := vr.ReadNull(); err != nil {
-		return err
-	}
-	// Set the zero value of val's type:
-	val.Set(d.zeroValue)
-	return nil
 }
 
 func NewClient(connection string) (Client, error) {


### PR DESCRIPTION
Hi!

After running staticcheck on the project, it funds a few errors:

**Deprecated**

> internal/tokenutil/tokenutil.go:16:19: jwt.StandardClaims is deprecated: Use RegisteredClaims instead for a forward-compatible way to access registered claims in a struct.  (SA1019)
> internal/tokenutil/tokenutil.go:31:19: jwt.StandardClaims is deprecated: Use RegisteredClaims instead for a forward-compatible way to access registered claims in a struct.  (SA1019)

**Unused**

> mongo/mongo.go:76:6: type nullawareDecoder is unused (U1000)
> mongo/mongo.go:81:28: func (*nullawareDecoder).DecodeValue is unused (U1000)

**Formatting**

> internal/tokenutil/tokenutil.go:46:16: error strings should not be capitalized (ST1005)
> internal/tokenutil/tokenutil.go:59:16: error strings should not be capitalized (ST1005)
> internal/tokenutil/tokenutil.go:71:14: error strings should not be capitalized (ST1005)

This PR will fix them, hopefully :)